### PR TITLE
Potential fix for code scanning alert no. 280: Log entries created from user input

### DIFF
--- a/Common/Services/Caching/CacheService.cs
+++ b/Common/Services/Caching/CacheService.cs
@@ -77,7 +77,8 @@ namespace Cosmos.Common.Services.Caching
             }
             catch (Exception ex)
             {
-                this.logger.LogError(ex, "Error setting cache entry for key {CacheKey} with absolute expiration {Expiration}", key, absoluteExpiration);
+                var safeKey = key?.Replace("\r", string.Empty).Replace("\n", string.Empty);
+                this.logger.LogError(ex, "Error setting cache entry for key {CacheKey} with absolute expiration {Expiration}", safeKey, absoluteExpiration);
                 throw;
             }
         }
@@ -108,10 +109,11 @@ namespace Cosmos.Common.Services.Caching
             }
             catch (Exception ex)
             {
+                var safeKey = key?.Replace("\r", string.Empty).Replace("\n", string.Empty);
                 this.logger.LogError(
                     ex,
                     "Error setting cache entry for key {CacheKey} with absolute expiration {AbsoluteExpiration} and sliding expiration {SlidingExpiration}",
-                    key,
+                    safeKey,
                     absoluteExpiration,
                     slidingExpiration);
                 throw;
@@ -132,7 +134,8 @@ namespace Cosmos.Common.Services.Caching
             }
             catch (Exception ex)
             {
-                this.logger.LogError(ex, "Error removing cache entry for key {CacheKey}", key);
+                var safeKey = key?.Replace("\r", string.Empty).Replace("\n", string.Empty);
+                this.logger.LogError(ex, "Error removing cache entry for key {CacheKey}", safeKey);
                 throw;
             }
         }


### PR DESCRIPTION
Potential fix for [https://github.com/CWALabs/SkyCMS/security/code-scanning/280](https://github.com/CWALabs/SkyCMS/security/code-scanning/280)

In general, to fix log-forging risks, any user-controlled data included in log messages should be normalized so it cannot inject line breaks or control characters, or, for HTML logs, should be HTML-encoded. Here the problematic value is the cache key, which ultimately depends on the HTTP path. The simplest fix that preserves behavior is to sanitize the cache key only at the point where it is logged, leaving its value unchanged for use as an actual key in the cache.

The best targeted fix is inside `CacheService<T>`’s `Set` method that takes `TimeSpan? absoluteExpiration, TimeSpan? slidingExpiration`. In the `catch` block, instead of logging `key` directly, create a sanitized version that removes `\r` and `\n` and use that in the log message. This avoids changing cache behavior or the shape of keys while ensuring logs cannot be forged via newlines in the key. We don’t need new imports; we can use `string.Replace` from `System`, which is already imported. We’ll make an analogous change to the other `Set` overload and to `Remove` as they also log `{CacheKey}` — even though CodeQL highlighted only one, the same risk exists there.

Concretely:
- In `Set(string key, T value, TimeSpan absoluteExpiration)`, in the `catch` block, introduce `var safeKey = key?.Replace("\r", string.Empty).Replace("\n", string.Empty);` and log `safeKey` instead of `key`.
- In `Set(string key, T value, TimeSpan? absoluteExpiration, TimeSpan? slidingExpiration)`, do the same.
- In `Remove(string key)`, likewise, sanitize `key` before logging it.

No changes are required in `PubControllerBase` or `CacheKeyProvider`, since the risky operation is logging, not key generation or use.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
